### PR TITLE
Add build-Realease to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ app/android/AndroidManifest.xml
 app/android/res/raw/
 compile_flags.txt
 tags
+build-Release/
+


### PR DESCRIPTION
Keeps showing up and modifying my submodule, I think I saw it on Jeff's computer too. Also we're 36 commits behind master is that an issue? Probably not you want to make sure you have a stable version in your code and only update when need be. 

Do I merge to master or devel?

Or should we have the installer script delete the folder after it is installed?